### PR TITLE
Refactor: move Items#create into API::V1::Items controller instead of…

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -6,4 +6,14 @@ class Api::V1::ItemsController < ApplicationController
   def show
     render json: Item.find(params[:id])
   end
+
+  def create
+    render json: Item.create(item_params)
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+  end
 end

--- a/app/controllers/api/v1/merchant/items_controller.rb
+++ b/app/controllers/api/v1/merchant/items_controller.rb
@@ -3,14 +3,4 @@ class Api::V1::Merchant::ItemsController < ApplicationController
     merchant = Merchant.find(params[:merchant_id])
     render json: merchant.items
   end
-
-  def create
-    render json: Item.create(item_params)
-  end
-
-  private
-
-  def item_params
-    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :items, only: [:index, :show]
+      resources :items, only: [:index, :show, :create]
       resources :merchants, only: [:index, :show] do
-        resources :items, only: [:index, :create], controller: "merchant/items"
+        resources :items, only: [:index], controller: "merchant/items"
       end
     end
   end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -76,7 +76,7 @@ describe "Items API" do
     }
     headers = {"CONTENT_TYPE" => "application/json"}
 
-    post "/api/v1/merchants/#{merchant_1.id}/items", headers: headers, params: JSON.generate(item: item_params)
+    post "/api/v1/items", headers: headers, params: JSON.generate(item: item_params)
 
     created_item = Item.last
 


### PR DESCRIPTION
This branch accomplishes the following: 

-updates the path for `Item` creation so that it takes place in the `API::V1::Items` controller instead of being nested inside the `API::V1::Merchant::Items` controller 