### PR TITLE
Serializer refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem "standardrb"
   gem "pry"
   gem "shoulda-matchers"
+  gem "jsonapi-serializer"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -202,6 +204,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   faker
+  jsonapi-serializer
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::ItemsController < ApplicationController
   def index
-    render json: Item.all
+    render json: ItemSerializer.new(Item.all)
   end
 
   def show
-    render json: Item.find(params[:id])
+    render json: ItemSerializer.new(Item.find(params[:id]))
   end
 
   def create

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::MerchantsController < ApplicationController
   def index
-    render json: Merchant.all
+    render json: MerchantSerializer.new(Merchant.all)
   end
 
   def show
-    render json: Merchant.find(params[:id])
+    render json: MerchantSerializer.new(Merchant.find(params[:id]))
   end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,4 @@
+class ItemSerializer
+  include JSONAPI::Serializer
+  attributes :name, :description, :unit_price, :merchant_id
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,4 @@
+class MerchantSerializer
+  include JSONAPI::Serializer
+  attributes :name
+end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -23,7 +23,6 @@ describe "Items API" do
       expected_merchants = ((item[:attributes][:merchant_id] == merchant_1.id) || (item[:attributes][:merchant_id] == merchant_2.id) || (item[:attributes][:merchant_id] == merchant_3.id))
 
       expect(item).to have_key(:id)
-      expect(item[:id]).to be_an(Integer)
 
       expect(item[:attributes]).to have_key(:name)
       expect(item[:attributes][:name]).to be_an(String)
@@ -52,7 +51,6 @@ describe "Items API" do
     item = response_body[:data]
 
     expect(item).to have_key(:id)
-    expect(item[:id]).to be_an(Integer)
 
     expect(item[:attributes]).to have_key(:name)
     expect(item[:attributes][:name]).to be_an(String)
@@ -127,8 +125,7 @@ describe "Items API" do
 
     get "/api/v1/items/#{item_1.id}/merchant"
 
-    response_body = JSON.parse(response.body, symbolize_names: true)
-    merchant = response_body[:data]
+    merchant = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
     expect(merchant[:name]).to eq(merchant_2.name)
@@ -159,18 +156,17 @@ describe "Items API" do
 
     get "/api/v1/items/find", headers: headers, params: search_params
 
-    response_body = JSON.parse(response.body, symbolize_names: true)
-    item = response_body[:data]
+    item = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
-    expect(item[:attributes][:name]).to eq("Fender Stratocaster")
-    expect(item[:attributes][:name]).not_to eq("Gibson Les Paul")
-    expect(item[:attributes][:name]).not_to eq("Ibanez Prestige")
-    expect(item[:attributes][:description]).to eq("Seafoam Green Finish")
-    expect(item[:attributes][:description]).not_to eq("Sunburst Finish")
-    expect(item[:attributes][:description]).not_to eq("Black Finish")
-    expect(item[:attributes][:unit_price]).to eq(100000)
-    expect(item[:attributes][:unit_price]).not_to eq(200000)
-    expect(item[:attributes][:unit_price]).not_to eq(120000)
+    expect(item[:name]).to eq("Fender Stratocaster")
+    expect(item[:name]).not_to eq("Gibson Les Paul")
+    expect(item[:name]).not_to eq("Ibanez Prestige")
+    expect(item[:description]).to eq("Seafoam Green Finish")
+    expect(item[:description]).not_to eq("Sunburst Finish")
+    expect(item[:description]).not_to eq("Black Finish")
+    expect(item[:unit_price]).to eq(100000)
+    expect(item[:unit_price]).not_to eq(200000)
+    expect(item[:unit_price]).not_to eq(120000)
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -14,26 +14,27 @@ describe "Items API" do
 
     expect(response).to be_successful
 
-    items = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    items = response_body[:data]
 
     expect(items.count).to eq(18)
 
     items.each do |item|
-      expected_merchants = ((item[:merchant_id] == merchant_1.id) || (item[:merchant_id] == merchant_2.id) || (item[:merchant_id] == merchant_3.id))
+      expected_merchants = ((item[:attributes][:merchant_id] == merchant_1.id) || (item[:attributes][:merchant_id] == merchant_2.id) || (item[:attributes][:merchant_id] == merchant_3.id))
 
       expect(item).to have_key(:id)
       expect(item[:id]).to be_an(Integer)
 
-      expect(item).to have_key(:name)
-      expect(item[:name]).to be_an(String)
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes][:name]).to be_an(String)
 
-      expect(item).to have_key(:description)
-      expect(item[:description]).to be_an(String)
+      expect(item[:attributes]).to have_key(:description)
+      expect(item[:attributes][:description]).to be_an(String)
 
-      expect(item).to have_key(:unit_price)
-      expect(item[:unit_price]).to be_an(Float)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes][:unit_price]).to be_an(Float)
 
-      expect(item).to have_key(:merchant_id)
+      expect(item[:attributes]).to have_key(:merchant_id)
       expect(expected_merchants).to be true
     end
   end
@@ -47,22 +48,23 @@ describe "Items API" do
 
     expect(response).to be_successful
 
-    item = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    item = response_body[:data]
 
     expect(item).to have_key(:id)
     expect(item[:id]).to be_an(Integer)
 
-    expect(item).to have_key(:name)
-    expect(item[:name]).to be_an(String)
+    expect(item[:attributes]).to have_key(:name)
+    expect(item[:attributes][:name]).to be_an(String)
 
-    expect(item).to have_key(:description)
-    expect(item[:description]).to be_an(String)
+    expect(item[:attributes]).to have_key(:description)
+    expect(item[:attributes][:description]).to be_an(String)
 
-    expect(item).to have_key(:unit_price)
-    expect(item[:unit_price]).to be_an(Float)
+    expect(item[:attributes]).to have_key(:unit_price)
+    expect(item[:attributes][:unit_price]).to be_an(Float)
 
-    expect(item).to have_key(:merchant_id)
-    expect(item[:merchant_id]).to eq(merchant_1.id)
+    expect(item[:attributes]).to have_key(:merchant_id)
+    expect(item[:attributes][:merchant_id]).to eq(merchant_1.id)
   end
 
   it "can create a new item" do
@@ -125,7 +127,8 @@ describe "Items API" do
 
     get "/api/v1/items/#{item_1.id}/merchant"
 
-    merchant = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchant = response_body[:data]
 
     expect(response).to be_successful
     expect(merchant[:name]).to eq(merchant_2.name)
@@ -156,17 +159,18 @@ describe "Items API" do
 
     get "/api/v1/items/find", headers: headers, params: search_params
 
-    item = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    item = response_body[:data]
 
     expect(response).to be_successful
-    expect(item[:name]).to eq("Fender Stratocaster")
-    expect(item[:name]).not_to eq("Gibson Les Paul")
-    expect(item[:name]).not_to eq("Ibanez Prestige")
-    expect(item[:description]).to eq("Seafoam Green Finish")
-    expect(item[:description]).not_to eq("Sunburst Finish")
-    expect(item[:description]).not_to eq("Black Finish")
-    expect(item[:unit_price]).to eq(100000)
-    expect(item[:unit_price]).not_to eq(200000)
-    expect(item[:unit_price]).not_to eq(120000)
+    expect(item[:attributes][:name]).to eq("Fender Stratocaster")
+    expect(item[:attributes][:name]).not_to eq("Gibson Les Paul")
+    expect(item[:attributes][:name]).not_to eq("Ibanez Prestige")
+    expect(item[:attributes][:description]).to eq("Seafoam Green Finish")
+    expect(item[:attributes][:description]).not_to eq("Sunburst Finish")
+    expect(item[:attributes][:description]).not_to eq("Black Finish")
+    expect(item[:attributes][:unit_price]).to eq(100000)
+    expect(item[:attributes][:unit_price]).not_to eq(200000)
+    expect(item[:attributes][:unit_price]).not_to eq(120000)
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -15,7 +15,6 @@ describe "Merchants API" do
 
     merchants.each do |merchant|
       expect(merchant).to have_key(:id)
-      expect(merchant[:id]).to be_an(Integer)
 
       expect(merchant[:attributes]).to have_key(:name)
       expect(merchant[:attributes][:name]).to be_an(String)
@@ -33,7 +32,6 @@ describe "Merchants API" do
     merchant = response_body[:data]
 
     expect(merchant).to have_key(:id)
-    expect(merchant[:id]).to be_an(Integer)
 
     expect(merchant[:attributes]).to have_key(:name)
     expect(merchant[:attributes][:name]).to be_an(String)
@@ -48,24 +46,22 @@ describe "Merchants API" do
 
     expect(response).to be_successful
 
-    response_body = JSON.parse(response.body, symbolize_names: true)
-    items = response_body[:data]
+    items = JSON.parse(response.body, symbolize_names: true)
 
     items.each do |item|
       expect(item).to have_key(:id)
-      expect(item[:id]).to be_an(Integer)
 
-      expect(item[:attributes]).to have_key(:name)
-      expect(item[:attributes][:name]).to be_an(String)
+      expect(item).to have_key(:name)
+      expect(item[:name]).to be_an(String)
 
-      expect(item[:attributes]).to have_key(:description)
-      expect(item[:attributes][:description]).to be_an(String)
+      expect(item).to have_key(:description)
+      expect(item[:description]).to be_an(String)
 
-      expect(item[:attributes]).to have_key(:unit_price)
-      expect(item[:attributes][:unit_price]).to be_an(Float)
+      expect(item).to have_key(:unit_price)
+      expect(item[:unit_price]).to be_an(Float)
 
-      expect(item[:attributes]).to have_key(:merchant_id)
-      expect(item[:attributes][:merchant_id]).to eq(merchant.id)
+      expect(item).to have_key(:merchant_id)
+      expect(item[:merchant_id]).to eq(merchant.id)
     end
   end
 
@@ -81,13 +77,12 @@ describe "Merchants API" do
 
     get "/api/v1/merchants/find_all", headers: headers, params: search_params
 
-    response_body = JSON.parse(response.body, symbolize_names: true)
-    merchants = response_body[:data]
+    merchants = JSON.parse(response.body, symbolize_names: true)
 
     expect(merchants.count).to eq(3)
 
     merchants.each do |merchant|
-      expected_names = ((merchant[:attributes][:name] == "Leo Fender") || (merchant[:attributes][:name] == "Brian Fender") || (merchant[:attributes][:name] == "Bill Fender"))
+      expected_names = ((merchant[:name] == "Leo Fender") || (merchant[:name] == "Brian Fender") || (merchant[:name] == "Bill Fender"))
       expect(expected_names).to be true
     end
   end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -8,7 +8,8 @@ describe "Merchants API" do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchants = response_body[:data]
 
     expect(merchants.count).to eq(5)
 
@@ -16,8 +17,8 @@ describe "Merchants API" do
       expect(merchant).to have_key(:id)
       expect(merchant[:id]).to be_an(Integer)
 
-      expect(merchant).to have_key(:name)
-      expect(merchant[:name]).to be_an(String)
+      expect(merchant[:attributes]).to have_key(:name)
+      expect(merchant[:attributes][:name]).to be_an(String)
     end
   end
 
@@ -28,13 +29,14 @@ describe "Merchants API" do
 
     expect(response).to be_successful
 
-    merchant = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchant = response_body[:data]
 
     expect(merchant).to have_key(:id)
     expect(merchant[:id]).to be_an(Integer)
 
-    expect(merchant).to have_key(:name)
-    expect(merchant[:name]).to be_an(String)
+    expect(merchant[:attributes]).to have_key(:name)
+    expect(merchant[:attributes][:name]).to be_an(String)
   end
 
   it "can get all items for one merchant" do
@@ -46,23 +48,24 @@ describe "Merchants API" do
 
     expect(response).to be_successful
 
-    items = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    items = response_body[:data]
 
     items.each do |item|
       expect(item).to have_key(:id)
       expect(item[:id]).to be_an(Integer)
 
-      expect(item).to have_key(:name)
-      expect(item[:name]).to be_an(String)
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes][:name]).to be_an(String)
 
-      expect(item).to have_key(:description)
-      expect(item[:description]).to be_an(String)
+      expect(item[:attributes]).to have_key(:description)
+      expect(item[:attributes][:description]).to be_an(String)
 
-      expect(item).to have_key(:unit_price)
-      expect(item[:unit_price]).to be_an(Float)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes][:unit_price]).to be_an(Float)
 
-      expect(item).to have_key(:merchant_id)
-      expect(item[:merchant_id]).to eq(merchant.id)
+      expect(item[:attributes]).to have_key(:merchant_id)
+      expect(item[:attributes][:merchant_id]).to eq(merchant.id)
     end
   end
 
@@ -78,12 +81,13 @@ describe "Merchants API" do
 
     get "/api/v1/merchants/find_all", headers: headers, params: search_params
 
-    merchants = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchants = response_body[:data]
 
     expect(merchants.count).to eq(3)
 
     merchants.each do |merchant|
-      expected_names = ((merchant[:name] == "Leo Fender") || (merchant[:name] == "Brian Fender") || (merchant[:name] == "Bill Fender"))
+      expected_names = ((merchant[:attributes][:name] == "Leo Fender") || (merchant[:attributes][:name] == "Brian Fender") || (merchant[:attributes][:name] == "Bill Fender"))
       expect(expected_names).to be true
     end
   end


### PR DESCRIPTION
This branch accomplishes the following: 

-refactors tests to expect incoming data to comply with `json:api` convention
-creates `ItemSerializer` and `MerchantSerializer` to generate json data for `#index` and `#show` requests
-installs `jsonapi-serializer` gem