### PR TITLE
Serializer refactor 2

### DIFF
--- a/app/controllers/api/v1/item/merchant_controller.rb
+++ b/app/controllers/api/v1/item/merchant_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Item::MerchantController < ApplicationController
   def index
     item = Item.find(params[:item_id])
-    render json: item.merchant
+    merchant = Merchant.find(item.merchant_id)
+    render json: MerchantSerializer.new(merchant)
   end
 end

--- a/app/controllers/api/v1/items/find_controller.rb
+++ b/app/controllers/api/v1/items/find_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::Items::FindController < ApplicationController
   def index
-    render json: Item.where("items.name LIKE ?", "%#{params[:name]}%")
+    item = Item.where("items.name LIKE ?", "%#{params[:name]}%")
       .order(:name)
       .first
+    render json: ItemSerializer.new(item)
   end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -8,11 +8,13 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def create
-    render json: Item.create(item_params)
+    item = Item.create(item_params)
+    render json: ItemSerializer.new(item)
   end
 
   def update
-    render json: Item.update(params[:id], item_params)
+    item = Item.update(params[:id], item_params)
+    render json: ItemSerializer.new(item)
   end
 
   def destroy

--- a/app/controllers/api/v1/merchant/items_controller.rb
+++ b/app/controllers/api/v1/merchant/items_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Merchant::ItemsController < ApplicationController
   def index
     merchant = Merchant.find(params[:merchant_id])
-    render json: merchant.items
+    render json: ItemSerializer.new(merchant.items)
   end
 end

--- a/app/controllers/api/v1/merchants/find_all_controller.rb
+++ b/app/controllers/api/v1/merchants/find_all_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Merchants::FindAllController < ApplicationController
   def index
-    render json: Merchant.where("merchants.name LIKE ?", "%#{params[:name]}%")
+    merchants = Merchant.where("merchants.name LIKE ?", "%#{params[:name]}%")
+    render json: MerchantSerializer.new(merchants)
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -78,13 +78,14 @@ describe "Items API" do
 
     post "/api/v1/items", headers: headers, params: JSON.generate(item: item_params)
 
-    created_item = Item.last
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    item = response_body[:data]
 
     expect(response).to be_successful
-    expect(created_item.name).to eq("1959 Gibson Les Paul")
-    expect(created_item.description).to eq("Sunburst Finish, Rosewood Fingerboard")
-    expect(created_item.unit_price).to eq(25000000)
-    expect(created_item.merchant_id).to eq(merchant_1.id)
+    expect(item[:attributes][:name]).to eq("1959 Gibson Les Paul")
+    expect(item[:attributes][:description]).to eq("Sunburst Finish, Rosewood Fingerboard")
+    expect(item[:attributes][:unit_price]).to eq(25000000)
+    expect(item[:attributes][:merchant_id]).to eq(merchant_1.id)
   end
 
   it "can update a given item" do
@@ -96,11 +97,12 @@ describe "Items API" do
 
     patch "/api/v1/items/#{id}", headers: headers, params: JSON.generate(item: item_params)
 
-    item = Item.find(id)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    item = response_body[:data]
 
     expect(response).to be_successful
-    expect(item.name).to eq("Homer Simpson")
-    expect(item.name).not_to eq(previous_name)
+    expect(item[:attributes][:name]).to eq("Homer Simpson")
+    expect(item[:attributes][:name]).not_to eq(previous_name)
   end
 
   it "can delete a given item" do

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -127,11 +127,12 @@ describe "Items API" do
 
     get "/api/v1/items/#{item_1.id}/merchant"
 
-    merchant = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchant = response_body[:data]
 
     expect(response).to be_successful
-    expect(merchant[:name]).to eq(merchant_2.name)
-    expect(merchant[:name]).not_to eq(merchant_1.name)
+    expect(merchant[:attributes][:name]).to eq(merchant_2.name)
+    expect(merchant[:attributes][:name]).not_to eq(merchant_1.name)
   end
 
   it "can send data for one item based on search criteria" do
@@ -158,17 +159,18 @@ describe "Items API" do
 
     get "/api/v1/items/find", headers: headers, params: search_params
 
-    item = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    item = response_body[:data]
 
     expect(response).to be_successful
-    expect(item[:name]).to eq("Fender Stratocaster")
-    expect(item[:name]).not_to eq("Gibson Les Paul")
-    expect(item[:name]).not_to eq("Ibanez Prestige")
-    expect(item[:description]).to eq("Seafoam Green Finish")
-    expect(item[:description]).not_to eq("Sunburst Finish")
-    expect(item[:description]).not_to eq("Black Finish")
-    expect(item[:unit_price]).to eq(100000)
-    expect(item[:unit_price]).not_to eq(200000)
-    expect(item[:unit_price]).not_to eq(120000)
+    expect(item[:attributes][:name]).to eq("Fender Stratocaster")
+    expect(item[:attributes][:name]).not_to eq("Gibson Les Paul")
+    expect(item[:attributes][:name]).not_to eq("Ibanez Prestige")
+    expect(item[:attributes][:description]).to eq("Seafoam Green Finish")
+    expect(item[:attributes][:description]).not_to eq("Sunburst Finish")
+    expect(item[:attributes][:description]).not_to eq("Black Finish")
+    expect(item[:attributes][:unit_price]).to eq(100000)
+    expect(item[:attributes][:unit_price]).not_to eq(200000)
+    expect(item[:attributes][:unit_price]).not_to eq(120000)
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -46,22 +46,23 @@ describe "Merchants API" do
 
     expect(response).to be_successful
 
-    items = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    items = response_body[:data]
 
     items.each do |item|
       expect(item).to have_key(:id)
 
-      expect(item).to have_key(:name)
-      expect(item[:name]).to be_an(String)
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes][:name]).to be_an(String)
 
-      expect(item).to have_key(:description)
-      expect(item[:description]).to be_an(String)
+      expect(item[:attributes]).to have_key(:description)
+      expect(item[:attributes][:description]).to be_an(String)
 
-      expect(item).to have_key(:unit_price)
-      expect(item[:unit_price]).to be_an(Float)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes][:unit_price]).to be_an(Float)
 
-      expect(item).to have_key(:merchant_id)
-      expect(item[:merchant_id]).to eq(merchant.id)
+      expect(item[:attributes]).to have_key(:merchant_id)
+      expect(item[:attributes][:merchant_id]).to eq(merchant.id)
     end
   end
 
@@ -77,12 +78,13 @@ describe "Merchants API" do
 
     get "/api/v1/merchants/find_all", headers: headers, params: search_params
 
-    merchants = JSON.parse(response.body, symbolize_names: true)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    merchants = response_body[:data]
 
     expect(merchants.count).to eq(3)
 
     merchants.each do |merchant|
-      expected_names = ((merchant[:name] == "Leo Fender") || (merchant[:name] == "Brian Fender") || (merchant[:name] == "Bill Fender"))
+      expected_names = ((merchant[:attributes][:name] == "Leo Fender") || (merchant[:attributes][:name] == "Brian Fender") || (merchant[:attributes][:name] == "Bill Fender"))
       expect(expected_names).to be true
     end
   end


### PR DESCRIPTION
This branch accomplishes the following: 

-updates all tests to expect responses to comply with `json:api` convention
-refactors all controller actions to utilize Serializers, except for `Items#destroy`