### PR TITLE
Refactor: update ItemSerializer so that merchant_id is not listed as …

### DIFF
--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,4 @@
 class ItemSerializer
   include JSONAPI::Serializer
-  attributes :name, :description, :unit_price, :merchant_id
+  attributes :name, :description, :unit_price
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -20,8 +20,6 @@ describe "Items API" do
     expect(items.count).to eq(18)
 
     items.each do |item|
-      expected_merchants = ((item[:attributes][:merchant_id] == merchant_1.id) || (item[:attributes][:merchant_id] == merchant_2.id) || (item[:attributes][:merchant_id] == merchant_3.id))
-
       expect(item).to have_key(:id)
 
       expect(item[:attributes]).to have_key(:name)
@@ -32,9 +30,6 @@ describe "Items API" do
 
       expect(item[:attributes]).to have_key(:unit_price)
       expect(item[:attributes][:unit_price]).to be_an(Float)
-
-      expect(item[:attributes]).to have_key(:merchant_id)
-      expect(expected_merchants).to be true
     end
   end
 
@@ -60,9 +55,6 @@ describe "Items API" do
 
     expect(item[:attributes]).to have_key(:unit_price)
     expect(item[:attributes][:unit_price]).to be_an(Float)
-
-    expect(item[:attributes]).to have_key(:merchant_id)
-    expect(item[:attributes][:merchant_id]).to eq(merchant_1.id)
   end
 
   it "can create a new item" do
@@ -85,7 +77,6 @@ describe "Items API" do
     expect(item[:attributes][:name]).to eq("1959 Gibson Les Paul")
     expect(item[:attributes][:description]).to eq("Sunburst Finish, Rosewood Fingerboard")
     expect(item[:attributes][:unit_price]).to eq(25000000)
-    expect(item[:attributes][:merchant_id]).to eq(merchant_1.id)
   end
 
   it "can update a given item" do

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -60,9 +60,6 @@ describe "Merchants API" do
 
       expect(item[:attributes]).to have_key(:unit_price)
       expect(item[:attributes][:unit_price]).to be_an(Float)
-
-      expect(item[:attributes]).to have_key(:merchant_id)
-      expect(item[:attributes][:merchant_id]).to eq(merchant.id)
     end
   end
 


### PR DESCRIPTION
This branch accomplishes the following: 

-refactors the `ItemSerializer` to remove `merchant_id` as an attribute